### PR TITLE
Add alternating lines in module compare tab to dark mode processing

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -172,6 +172,7 @@ int _GetSysColor(int nIndex) {
         case 5:
             return Configuration.Palette->dark;
         case 15:
+        case 22: //alternating lines in compare list
             return Configuration.Palette->midDark;
         case 8:
             return Configuration.Palette->white;


### PR DESCRIPTION
As you may have noticed when looking at the Module Stats windows Compare tab every other line was white text on light grey background.  I found the index in _GetSys_Color that controls this and added it to your case statement so it's easily readable again.